### PR TITLE
No mask in indexer forward

### DIFF
--- a/indexer.py
+++ b/indexer.py
@@ -96,7 +96,7 @@ class Indexer:
                 #     inputs, output_hidden_states=True
                 # )
                 _, embedding = self.model.forward(
-                    tokens, 0, output_last_hidden_state=True, mask=attn_mask
+                    tokens, 0, output_last_hidden_state=True
                 )
                 del attn_mask
                 del tokens


### PR DESCRIPTION
Not sure how it worked before, but it's not working on my current local or in the gha run https://github.com/pytorch/pytorch/actions/runs/7821891026/job/21339811956

Maybe the model changed or I'm using a different version of torch somehow?