### PR TITLE
Do relative path in indexer, remove unused imports + vars

### DIFF
--- a/indexer.py
+++ b/indexer.py
@@ -1,9 +1,7 @@
 import json
 import os
-import sys
 import time
 from argparse import ArgumentParser
-from datetime import datetime
 
 import torch
 from config import TDArgs
@@ -46,8 +44,7 @@ class Indexer:
             if torch.cuda.is_available()
             else torch.device("cpu")
         )
-        x = torch.rand(1)
-        print(x.device)
+        print(self.device)
 
         # Create DataLoader
         dataset = GRANULARITIES[embedding_granularity](self.config)
@@ -141,7 +138,7 @@ class Indexer:
 
         try:
             os.mkdir(assets_path)
-        except FileExistsError as e:
+        except FileExistsError:
             pass
 
         torch.save(

--- a/retriever.py
+++ b/retriever.py
@@ -2,10 +2,8 @@ import json
 import os
 import time
 from argparse import ArgumentParser
-from collections import defaultdict
 from glob import glob
 from pathlib import Path
-from typing import Any, Dict, List
 
 import torch
 import torch.nn.functional as F
@@ -14,9 +12,7 @@ from gen_pr_items import PR_ITEMS
 
 from llama import Llama
 
-from preproc import get_functions
 from tokenizer import Tokenizer
-from transformers import AutoModelForCausalLM
 
 REPO_ROOT = Path(__file__).resolve().parent
 
@@ -87,7 +83,7 @@ class Retriever:
         self.model = generator.model.to(self.device)
         self.tokenizer = Tokenizer(self.config)
 
-    def retrieve(self) -> Dict[str, float]:
+    def retrieve(self) -> None:
         # parse and tokenize input (function from a file)
         # run model forward on each chunk of the embeddings
         # cosine similarity per chunk
@@ -128,8 +124,6 @@ class Retriever:
                         self.embeddings, pooled_embedding
                     )
 
-                    grouped_by_file = defaultdict(list)
-
                     for ind in range(similarity_matrix.shape[0]):
                         test = self.unittest_names[ind]
                         score = similarity_matrix[ind]
@@ -147,10 +141,7 @@ class Retriever:
         os.makedirs("assets/mappings", exist_ok=True)
         new_mapping = {}
         for file, score in mapping.items():
-            clean_file = os.path.relpath(
-                file, REPO_ROOT.parent / "pytorch/test"
-            )
-            new_mapping[clean_file] = score
+            new_mapping[file] = score
         with open(
             REPO_ROOT / "assets/mappings" / self.output_filename, "w"
         ) as f:

--- a/test_dataset.py
+++ b/test_dataset.py
@@ -1,16 +1,12 @@
-import ast
-import json
 import math
 import os
-import sys
-from collections import OrderedDict
 from pathlib import Path
-from typing import Dict, List, NamedTuple, Tuple
+from typing import List, NamedTuple, Tuple
 
 import torch
 from preproc import get_functions
 from tokenizer import Tokenizer
-from torch.utils.data import DataLoader, Dataset
+from torch.utils.data import Dataset
 
 REPO_ROOT = Path(__file__).resolve().parent
 
@@ -51,7 +47,6 @@ class UnittestDataset(Dataset):
         DistributedSampler correctly cover all the relevant files.
         """
         all_files = []
-        project_dir = Path(self.config.project_dir).expanduser()
 
         for root, dirs, files in os.walk(self.config.project_dir):
             for file in files:
@@ -194,8 +189,11 @@ class FileGranularityDataset(UnittestDataset):
         filename = self.filelist[idx]
         with open(filename) as f:
             text = f.read()
+        clean_path = os.path.relpath(
+            filename, REPO_ROOT.parent / "pytorch/test"
+        )
 
-        return self.tokenize_items([(filename, text)])
+        return self.tokenize_items([(clean_path, text)])
 
 
 def flatten(lst):


### PR DESCRIPTION
Do relative path in indexer rather than the retriever so the index doesn't contain unrelated file paths that might be different on the other machine (ex /var/lib/idk/csl/pytorch/test/testfile -> test/testfile)

Remove unused imports and vars